### PR TITLE
EDUCATION-246 Python 3.8 multiprocessing

### DIFF
--- a/ru202/src/python/consumer_group.py
+++ b/ru202/src/python/consumer_group.py
@@ -116,5 +116,4 @@ if __name__ == '__main__':
         consumers.append(new_consumer(f'BOB-{i}'))
 
     Thread(target=chaos_func, args=(consumers, )).start()
-    #Process(target=chaos_func, args=(consumers, )).start()
     producer_func()


### PR DESCRIPTION
Addresses issues with pickling weakrefs in Python 3.8.  