### PR TITLE
Updated venv activation cmd in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Execute these commands in your shell to clone the repository, create a Python vi
 git clone https://github.com/redislabs-training/ru202.git
 cd ru202
 python3 -m venv env
-. env/bin/activate
+. env/Scripts/activate
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
Updated the code block to activate the virtual environment in the Setup portion of the README file. The current version points to the bin folder as opposed to the Scripts folder which causes an error when trying to execute.