### PR TITLE
Fix typo in command name.

### DIFF
--- a/courseware/video_transcripts/section_6/ru202_6_3_1_going_back_in_time.srt
+++ b/courseware/video_transcripts/section_6/ru202_6_3_1_going_back_in_time.srt
@@ -44,7 +44,7 @@ up and go upstream.
 
 11
 00:00:25,440 --> 00:00:28,110
-That's what XREVERANGE is for.
+That's what XREVRANGE is for.
 
 12
 00:00:28,110 --> 00:00:32,340
@@ -80,7 +80,7 @@ that sums the natural numbers stream to use
 
 20
 00:00:52,630 --> 00:00:55,000
-XREVERANGE instead of XRANGE.
+XREVRANGE instead of XRANGE.
 
 21
 00:00:55,000 --> 00:00:57,910


### PR DESCRIPTION
Fixes a few instances of `XREVERANGE` in the transcript, should be `XREVRANGE`.

- [ ] Update 2023_02 course run
- [ ] Update staff course run
- [ ] Back up courses