### PR TITLE
Fixed for millisecond timestamps in entry IDs.

### DIFF
--- a/courseware/html/section_11/ru202_11_3_0_inspecting_the_dataset.html
+++ b/courseware/html/section_11/ru202_11_3_0_inspecting_the_dataset.html
@@ -26,11 +26,11 @@ $ redis-cli
 <p>Finally, let's see what the messages look like using <span class="code">XRANGE</span>:</p>
 <p><pre class="code">
 127.0.0.1:6379> XRANGE temps:20250105 - + COUNT 2
-1) 1) "1736035200-0"
+1) 1) "1736035200000-0"
    2) 1) "temp_f"
       2) "73"
-2) 1) "1736035201-0"
+2) 1) "1736035201000-0"
    2) 1) "temp_f"
       2) "72"
 </pre></p>
-<p>Each message's ID is the timestamp that the temperature reading is for (<span class="code">1736035200</span> = January 5th 2025 at 00:00 for example).  The payload is a single item named <span class="code">temp_f</span> whose value is the temperature reading in Fahrenheit.</p>
+<p>Each message&apos;s ID is the millisecond timestamp that the temperature reading is for (<span class="code">1736035200000</span> = January 5th 2025 at 00:00 for example).  The payload is a single item named <span class="code">temp_f</span> whose value is the temperature reading in Fahrenheit.</p>

--- a/courseware/html/section_11/ru202_11_5_0_recovering_a_crashed_consumer.html
+++ b/courseware/html/section_11/ru202_11_5_0_recovering_a_crashed_consumer.html
@@ -33,7 +33,7 @@ avg: Average temperature for 2025/01/01 at 2 was 83F (3600 observations).
 1) "current_stream_key"
 2) "temps:20250101"
 3) "last_message_id"
-4) "1735702767-0"
+4) "1735702767000-0"
 5) "current_hourly_total"
 6) "61857"
 7) "current_hourly_count"

--- a/src/week4/partitioned_stream_producer.py
+++ b/src/week4/partitioned_stream_producer.py
@@ -122,7 +122,7 @@ def main():
         # Pipeline: https://redis.io/topics/pipelining
         pipe = redis.pipeline()
         pipe.xadd(stream_key, entry, current_timestamp)
-        pipe.expireat(stream_key, current_timestamp + PARTITION_EXPIRY_TIME)
+        pipe.expireat(stream_key, (current_timestamp // 1000) + PARTITION_EXPIRY_TIME)
         pipe.execute()
 
         # Have we started a new stream?

--- a/src/week4/partitioned_stream_producer.py
+++ b/src/week4/partitioned_stream_producer.py
@@ -38,7 +38,7 @@ TEMPERATURE_READING_INTERVAL_SECONDS = 1
 # when the producer is run.  So this timestamp 
 # represents the oldest temperature reading that 
 # will be generated.
-TIMESTAMP_START = 1735689600 # 01/01/2025 00:00:00 UTC
+TIMESTAMP_START = 1735689600000 # 01/01/2025 00:00:00 UTC
 
 # Number of days of data to generate.
 DAYS_TO_GENERATE = 10
@@ -70,10 +70,10 @@ def reset_state():
 
     print("Deleting old streams:")
     for day in range(DAYS_TO_GENERATE):
-        stream_key_name = f"{const.STREAM_KEY_BASE}:{datetime.utcfromtimestamp(stream_timestamp).strftime('%Y%m%d')}"
+        stream_key_name = f"{const.STREAM_KEY_BASE}:{datetime.utcfromtimestamp(stream_timestamp // 1000).strftime('%Y%m%d')}"
         print(stream_key_name)
         keys_to_delete.append(stream_key_name)
-        stream_timestamp += ONE_DAY_SECONDS
+        stream_timestamp += (ONE_DAY_SECONDS * 1000)
         
     redis.delete(*keys_to_delete)
 
@@ -81,7 +81,7 @@ def reset_state():
 # the supplied timestamp in the format specified by
 # format_pattern.  See http://strftime.org/
 def format_timestamp_as_utc(timestamp, format_pattern):
-    return datetime.utcfromtimestamp(timestamp).strftime(format_pattern)
+    return datetime.utcfromtimestamp(timestamp // 1000).strftime(format_pattern)
 
 # Calculate key name for the stream partition that
 # the supplied timestamp belongs to.  Each day has 
@@ -98,7 +98,7 @@ def main():
     current_timestamp = TIMESTAMP_START
 
     # End data production a configurable number of days after we began.
-    end_timestamp = TIMESTAMP_START + (ONE_DAY_SECONDS * DAYS_TO_GENERATE)
+    end_timestamp = (TIMESTAMP_START + ((ONE_DAY_SECONDS * 1000) * DAYS_TO_GENERATE))
 
     redis = get_connection()
 
@@ -132,7 +132,7 @@ def main():
             previous_stream_key = stream_key            
 
         # Move on to the next timestamp value.
-        current_timestamp += TEMPERATURE_READING_INTERVAL_SECONDS
+        current_timestamp += (TEMPERATURE_READING_INTERVAL_SECONDS * 1000)
     
 if __name__ == "__main__":
     main()

--- a/src/week4/stream_consumers.py
+++ b/src/week4/stream_consumers.py
@@ -156,14 +156,14 @@ def aggregating_consumer_func(current_stream_key, last_message_id, current_hourl
             msg_temperature = msg[1]["temp_f"]
 
             # Get hour for this message
-            msg_date = datetime.utcfromtimestamp(int(msg_timestamp))
+            msg_date = datetime.utcfromtimestamp(int(msg_timestamp) // 1000)
             msg_hour = msg_date.hour
 
             # Get the hour for the last message
             last_message_hour = 0
             if "-" in last_message_id:
                 last_message_timestamp = last_message_id.split("-")[0]
-                last_message_date = datetime.utcfromtimestamp(int(last_message_timestamp))
+                last_message_date = datetime.utcfromtimestamp(int(last_message_timestamp) // 1000)
                 last_message_hour = last_message_date.hour
 
             # Did we start a new hour?


### PR DESCRIPTION
Makes the example stream entry IDs use millisecond timestamps as RedisInsight then renders them as dates properly.

Closes #14

- [x] Check the code works
- [x] Amend any HTML sections - 11.3 & 11.5
- [x] Deploy to 2023_02 course run
- [x] Deploy to staff self paced run
- [x] Back up courses